### PR TITLE
fix utf-8 encoding error in capture, closes #17

### DIFF
--- a/lib/sinatra/capture.rb
+++ b/lib/sinatra/capture.rb
@@ -7,17 +7,20 @@ module Sinatra
     include Sinatra::EngineTracking
 
     DUMMIES = {
-      :haml => "!= capture_haml(*args, &block)",
-      :erb  => "<% @capture = yield(*args) %>",
-      :slim => "== yield(*args)"
+      :haml   => "!= capture_haml(*args, &block)",
+      :erubis => "<% @capture = yield(*args) %>",
+      :slim   => "== yield(*args)"
     }
-
-    DUMMIES[:erubis] = DUMMIES[:erb]
 
     def capture(*args, &block)
       @capture = nil
       if current_engine == :ruby
         result = block[*args]
+      elsif current_engine == :erb
+        @_out_buf, _buf_was = '', @_out_buf
+        block[*args]
+        result = eval('@_out_buf', block.binding)
+        @_out_buf = _buf_was
       else
         buffer     = eval '_buf if defined?(_buf)', block.binding
         old_buffer = buffer.dup if buffer

--- a/spec/capture_spec.rb
+++ b/spec/capture_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'backports'
 require 'slim'
 require_relative 'spec_helper'
@@ -32,8 +33,15 @@ describe Sinatra::Capture do
 
   describe('haml')   { it_behaves_like "a template language", :haml   }
   describe('slim')   { it_behaves_like "a template language", :slim   }
-  describe('erb')    { it_behaves_like "a template language", :erb    }
   describe('erubis') { it_behaves_like "a template language", :erubis }
+
+  describe 'erb' do
+    it_behaves_like "a template language", :erb
+
+    it "handles utf-8 encoding" do
+      render(:erb, "utf_8").should == "UTF-8 –"
+    end
+  end
 end
 
 __END__
@@ -78,3 +86,7 @@ Say
     World
   #{b.strip}!
 Hello #{a.strip}
+
+@@ utf_8
+<% a = capture do %>–<% end %>
+UTF-8 <%= a %>


### PR DESCRIPTION
The problem was with dummy templates in `lib/sinatra/capture.rb` and existed only for erb engine.
I've written spec and set utf-8 encoding to this file.
