### PR TITLE
require_relative not needed in specs as spec dir is in load path

### DIFF
--- a/spec/capture_spec.rb
+++ b/spec/capture_spec.rb
@@ -1,6 +1,5 @@
-require 'backports'
+require 'spec_helper'
 require 'slim'
-require_relative 'spec_helper'
 
 describe Sinatra::Capture do
   subject do

--- a/spec/config_file_spec.rb
+++ b/spec/config_file_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe Sinatra::ConfigFile do
   def config_file(*args, &block)

--- a/spec/content_for_spec.rb
+++ b/spec/content_for_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe Sinatra::ContentFor do
   subject do

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe Sinatra::Cookies do
   def cookie_route(*cookies, &block)

--- a/spec/decompile_spec.rb
+++ b/spec/decompile_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 RSpec::Matchers.define :decompile do |path|
   match do |app|

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe Sinatra::Extension do
   module ExampleExtension

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -1,6 +1,5 @@
-require 'backports'
-require_relative 'spec_helper'
-require_relative 'okjson'
+require 'spec_helper'
+require 'okjson'
 
 shared_examples_for "a json encoder" do |lib, const|
   before do

--- a/spec/link_header_spec.rb
+++ b/spec/link_header_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe Sinatra::LinkHeader do
   before do

--- a/spec/multi_route_spec.rb
+++ b/spec/multi_route_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe Sinatra::MultiRoute do
   before do

--- a/spec/namespace_spec.rb
+++ b/spec/namespace_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe Sinatra::Namespace do
   verbs = [:get, :head, :post, :put, :delete, :options]

--- a/spec/reloader_spec.rb
+++ b/spec/reloader_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 require 'fileutils'
 
 describe Sinatra::Reloader do

--- a/spec/respond_with_spec.rb
+++ b/spec/respond_with_spec.rb
@@ -1,6 +1,5 @@
-require 'backports'
-require_relative 'spec_helper'
-require_relative 'okjson'
+require 'spec_helper'
+require 'okjson'
 
 describe Sinatra::RespondWith do
   def provides(*args)

--- a/spec/streaming_spec.rb
+++ b/spec/streaming_spec.rb
@@ -1,5 +1,4 @@
-require 'backports'
-require_relative 'spec_helper'
+require 'spec_helper'
 
 describe Sinatra::Streaming do
   def stream(&block)


### PR DESCRIPTION
RSpec puts spec directory into LOAD_PATH, so there is no need to:

```
require 'backports'
require_relative 'spec_helper'
```

We could use just

```
require 'spec_helper'
```
