### PR TITLE
fixes small omission in one of the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ All extensions:
 
 ``` ruby
 require 'sinatra/base'
-require 'sinatra/contrib'
+require 'sinatra/contrib/all'
 
 class MyApp < Sinatra::Base
   register Sinatra::Contrib


### PR DESCRIPTION
The last example was missing the full require path for loading all contrib extensions
