### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,58 +1,54 @@
 GIT
   remote: git://github.com/sinatra/sinatra
-  revision: 962d3f549ec6b7a2adbbee8438f03b28cdf80d6f
+  revision: b882ab37df7d0a850d6e2091507dbc66d1ae2ea0
   specs:
-    sinatra (1.3.0)
-      rack (~> 1.3)
-      tilt (~> 1.3)
+    sinatra (1.4.0)
+      rack (~> 1.3, >= 1.3.6)
+      rack-protection (~> 1.2)
+      tilt (~> 1.3, >= 1.3.3)
 
 PATH
   remote: .
   specs:
-    sinatra-contrib (1.3.0)
+    sinatra-contrib (1.4.0)
       backports (>= 2.0)
       eventmachine
       rack-protection
       rack-test
-      sinatra (~> 1.3.0)
+      sinatra (~> 1.4.0)
       tilt (~> 1.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
     backports (2.3.0)
-    diff-lcs (1.1.2)
+    diff-lcs (1.1.3)
     erubis (2.7.0)
-    escape_utils (0.2.3)
     eventmachine (0.12.10)
-    eventmachine (0.12.10-java)
-    haml (3.1.2)
-    json (1.5.1)
-    json (1.5.1-java)
-    rack (1.3.2)
-    rack-protection (0.1.0)
-      escape_utils
+    haml (3.1.4)
+    json (1.6.5)
+    rack (1.4.1)
+    rack-protection (1.2.0)
       rack
     rack-test (0.6.1)
       rack (>= 1.0)
-    rake (0.9.2)
-    rspec (2.6.0)
-      rspec-core (~> 2.6.0)
-      rspec-expectations (~> 2.6.0)
-      rspec-mocks (~> 2.6.0)
-    rspec-core (2.6.4)
-    rspec-expectations (2.6.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.6.0)
-    slim (0.9.4)
-      temple (~> 0.3.0)
-      tilt (~> 1.2)
-    temple (0.3.1)
-    tilt (1.3.2)
-    yajl-ruby (0.8.3)
+    rake (0.9.2.2)
+    rspec (2.9.0)
+      rspec-core (~> 2.9.0)
+      rspec-expectations (~> 2.9.0)
+      rspec-mocks (~> 2.9.0)
+    rspec-core (2.9.0)
+    rspec-expectations (2.9.0)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.9.0)
+    slim (1.1.1)
+      temple (~> 0.4.0)
+      tilt (~> 1.3.2)
+    temple (0.4.0)
+    tilt (1.3.3)
+    yajl-ruby (1.1.0)
 
 PLATFORMS
-  java
   ruby
 
 DEPENDENCIES

--- a/sinatra-contrib.gemspec
+++ b/sinatra-contrib.gemspec
@@ -1,7 +1,7 @@
 # Run `rake sinatra-contrib.gemspec` to update the gemspec.
 Gem::Specification.new do |s|
   s.name        = "sinatra-contrib"
-  s.version     = "1.3.2"
+  s.version     = "1.4.0"
   s.description = "Collection of useful Sinatra extensions"
   s.homepage    = "http://github.com/sinatra/sinatra-contrib"
   s.summary     = s.description
@@ -111,7 +111,7 @@ Gem::Specification.new do |s|
     "spec/streaming_spec.rb"
   ]
 
-  s.add_dependency "sinatra",   "~> 1.3.0"
+  s.add_dependency "sinatra",   "~> 1.4.0"
   s.add_dependency "backports", ">= 2.0"
   s.add_dependency "tilt",      "~> 1.3"
   s.add_dependency "rack-test"


### PR DESCRIPTION
This allows us to use sinatra-contrib with the edge version of sinatra.
