### PR TITLE
default JSON encoder: encode nil to "null" instead of "nil"

### DIFF
--- a/lib/sinatra/json.rb
+++ b/lib/sinatra/json.rb
@@ -100,7 +100,8 @@ module Sinatra
         fail "invalid: #{o.inspect}" unless a.empty? or a.include? o.class
         case o
         when Float  then o.nan? || o.infinite? ? 'null' : o.inspect
-        when TrueClass, FalseClass, NilClass, Numeric, String then o.inspect
+        when TrueClass, FalseClass, Numeric, String then o.inspect
+        when NilClass then 'null'
         when Array  then map(o, "[%s]") { |e| enc(e) }
         when Hash   then map(o, "{%s}") { |k,v| enc(k, String) + ":" + enc(v) }
         end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -41,8 +41,8 @@ describe Sinatra::JSON do
   end
 
   it "encodes objects to json out of the box" do
-    mock_app { get('/') { json :foo => [1, 'bar'] } }
-    results_in 'foo' => [1, 'bar']
+    mock_app { get('/') { json :foo => [1, 'bar', nil] } }
+    results_in 'foo' => [1, 'bar', nil]
   end
 
   it "sets the content type to 'application/json'" do


### PR DESCRIPTION
small fix for the packaged json encoder
