### PR TITLE
StdLib JSON library not being found.

### DIFF
--- a/lib/sinatra/json.rb
+++ b/lib/sinatra/json.rb
@@ -125,7 +125,7 @@ module Sinatra
 
   Base.set :json_encoder do
     return Yajl::Encoder if defined? Yajl::Encoder
-    return JSON if defined? JSON
+    return ::JSON if defined? ::JSON
     return :to_json if {}.respond_to? :to_json and [].respond_to? :to_json
     Sinatra::JSON
   end


### PR DESCRIPTION
Currently the StdLib JSON library doesn't get set as the default encoder. This fixes it.

Tried to write a test case around this and the other default encoders, but it's a really hard one to test for. Problem is that the default encoder logic is based on what gems (modules) are required in the global namespace. 

How do you un-require a gem once required in your test case? I don't think it's possible without some serious hacking that would create a big mess. Any ideas?  
