### PR TITLE
Relying on to_hash responders can break crappy classes which monkey patch arrays

### DIFF
--- a/lib/sinatra/config_file.rb
+++ b/lib/sinatra/config_file.rb
@@ -140,7 +140,7 @@ module Sinatra
         hash = hash[environment.to_s] || hash[environment.to_sym]
       end
 
-      if hash.respond_to? :to_hash
+      if hash.respond_to? :to_hash and hash.class != Array
         indifferent_hash = Hash.new {|hash,key| hash[key.to_s] if Symbol === key }
         indifferent_hash.merge hash.to_hash
       else


### PR DESCRIPTION
Some DM-core classes like to open up Array and throw in an to_hash into it.

So a proper YAML file MIGHT end up looking horrible depending on if that DM-core had been loaded yet or not. A nice array of Hashes then gets turned into { { :key => 'value' } => nil }.

Can we not convert it to a hash if it is an Array? Do you foresee any problems with that?
