### PR TITLE
Use MultiJSON

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ PATH
     sinatra-contrib (1.4.0)
       backports (>= 2.0)
       eventmachine
+      multi_json
       rack-protection
       rack-test
       sinatra (~> 1.4.0)
@@ -27,6 +28,7 @@ GEM
     eventmachine (0.12.10)
     haml (3.1.4)
     json (1.6.5)
+    multi_json (1.3.6)
     rack (1.4.1)
     rack-protection (1.2.0)
       rack

--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ Currently included:
 * `sinatra/engine_tracking`: Adds methods like `haml?` that allow helper
   methods to check whether they are called from within a template.
 
-* `sinatra/json`: Adds a `#json` helper method to return JSON documents.
+* `sinatra/json`: See multi_json. This one kept around for
+  backward-compatibility.
 
 * `sinatra/link_header`: Helpers for generating `link` HTML tags and
   corresponding `Link` HTTP headers. Adds `link`, `stylesheet` and `prefetch`
   helper methods.
+
+* `sinatra/multi_json`: Adds a `#json` helper method to return JSON documents.
 
 * `sinatra/multi_route`: Adds ability to define one route block for multiple
   routes and multiple or custom HTTP verbs.

--- a/lib/sinatra/contrib.rb
+++ b/lib/sinatra/contrib.rb
@@ -16,7 +16,7 @@ module Sinatra
       helpers :ContentFor
       helpers :Cookies
       helpers :EngineTracking
-      helpers :JSON
+      helpers :MultiJSON
       helpers :LinkHeader
       helpers :Streaming
     end
@@ -27,6 +27,7 @@ module Sinatra
       # register :Compass
       register :Decompile
       register :Reloader
+      register :JSON
     end
 
     ##

--- a/lib/sinatra/multi_json.rb
+++ b/lib/sinatra/multi_json.rb
@@ -1,0 +1,87 @@
+require 'sinatra/base'
+require 'multi_json'
+
+module Sinatra
+
+  # = Sinatra::MultiJSON
+  #
+  # <tt>Sinatra::MultiJson</tt> adds a helper method, called +json+, for (obviously)
+  # json generation.
+  #
+  # == Usage
+  #
+  # === Classic Application
+  #
+  # In a classic application simply require the helper, and start using it:
+  #
+  #     require "sinatra"
+  #     require "sinatra/multi_json"
+  #
+  #     # define a route that uses the helper
+  #     get '/' do
+  #       json :foo => 'bar'
+  #     end
+  #
+  #     # The rest of your classic application code goes here...
+  #
+  # === Modular Application
+  #
+  # In a modular application you need to require the helper, and then tell the
+  # application you will use it:
+  #
+  #     require "sinatra/base"
+  #     require "sinatra/multi_json"
+  #
+  #     class MyApp < Sinatra::Base
+  #       helpers Sinatra::MultiJSON
+  #
+  #       # define a route that uses the helper
+  #       get '/' do
+  #         json :foo => 'bar'
+  #       end
+  #
+  #       # The rest of your modular application code goes here...
+  #     end
+  #
+  # === Encoders
+  #
+  # The {MultiJSON gem}[https://rubygems.org/gems/multi_json] tries to find
+  # the best JSON encoder available. You can specify an encoder using one of
+  # MultiJson's options:
+  #
+  #   set :multi_json_encoder, :json_gem
+  #
+  # === Content-Type
+  #
+  # It will automatically set the content type to "application/json".  As
+  # usual, you can easily change that, with the <tt>:json_content_type</tt>
+  # setting:
+  #
+  #   set :json_content_type, :js
+  #
+  # === Overriding the Encoder and the Content-Type
+  #
+  # The +json+ helper will also take two options <tt>:encoder</tt> and
+  # <tt>:content_type</tt>.  The values of this options are the same as the
+  # <tt>:multi_json_encoder</tt> and <tt>:json_content_type</tt> settings,
+  # respectively.  You can also pass those to the json method:
+  #
+  #   get '/'  do
+  #     json({:foo => 'bar'}, :encoder => :yajl, :content_type => :js)
+  #   end
+  #
+  module MultiJSON
+    def json(object, options = {})
+      encoder = options[:encoder] || settings.multi_json_encoder
+      content_type options[:content_type] || settings.json_content_type
+      ::MultiJson.encode(object, :adapter => encoder)
+    end
+  end
+
+  Base.set :multi_json_encoder do
+    ::MultiJson.engine
+  end
+
+  Base.set :json_content_type, :json
+  helpers MultiJSON
+end

--- a/lib/sinatra/respond_with.rb
+++ b/lib/sinatra/respond_with.rb
@@ -1,4 +1,4 @@
-require 'sinatra/json'
+require 'sinatra/multi_json'
 require 'sinatra/base'
 
 module Sinatra
@@ -125,7 +125,7 @@ module Sinatra
     end
 
     module Helpers
-      include Sinatra::JSON
+      include Sinatra::MultiJSON
 
       def respond_with(template, object = nil, &block)
         object, template = template, nil unless Symbol === template

--- a/sinatra-contrib.gemspec
+++ b/sinatra-contrib.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |s|
     "lib/sinatra/extension.rb",
     "lib/sinatra/json.rb",
     "lib/sinatra/link_header.rb",
+    "lib/sinatra/multi_json.rb",
     "lib/sinatra/multi_route.rb",
     "lib/sinatra/namespace.rb",
     "lib/sinatra/reloader.rb",
@@ -96,6 +97,7 @@ Gem::Specification.new do |s|
     "spec/extension_spec.rb",
     "spec/json_spec.rb",
     "spec/link_header_spec.rb",
+    "spec/multi_json_spec.rb",
     "spec/multi_route_spec.rb",
     "spec/namespace/foo.erb",
     "spec/namespace/nested/foo.erb",
@@ -115,6 +117,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sinatra",   "~> 1.4.0"
   s.add_dependency "backports", ">= 2.0"
   s.add_dependency "tilt",      "~> 1.3"
+  s.add_dependency "multi_json"
   s.add_dependency "rack-test"
   s.add_dependency "rack-protection"
   s.add_dependency "eventmachine"

--- a/spec/multi_json_spec.rb
+++ b/spec/multi_json_spec.rb
@@ -1,0 +1,88 @@
+require 'backports'
+require_relative 'spec_helper'
+require_relative 'okjson'
+
+shared_examples_for "a multi_json encoder" do |lib, const|
+  before do
+    begin
+      require lib if lib
+      @encoder = const
+    rescue LoadError
+      pending "unable to load #{lib}"
+    end
+  end
+
+  it "allows setting :encoder to #{const}" do
+    enc = @encoder
+    mock_app { get('/') { json({'foo' => 'bar'}, :encoder => enc) }}
+    results_in 'foo' => 'bar'
+  end
+
+  it "allows setting settings.json_encoder to #{const}" do
+    enc = @encoder
+    mock_app do
+      set :json_encoder, enc
+      get('/') { json 'foo' => 'bar' }
+    end
+    results_in 'foo' => 'bar'
+  end
+end
+
+describe Sinatra::MultiJSON do
+  def mock_app(&block)
+    super do
+      helpers Sinatra::MultiJSON
+      class_eval(&block)
+    end
+  end
+
+  def results_in(obj)
+    OkJson.decode(get('/').body).should == obj
+  end
+
+  it "encodes objects to json out of the box" do
+    mock_app { get('/') { json :foo => [1, 'bar', nil] } }
+    results_in 'foo' => [1, 'bar', nil]
+  end
+
+  it "sets the content type to 'application/json'" do
+    mock_app { get('/') { json({}) } }
+    get('/')["Content-Type"].should include("application/json")
+  end
+
+  it "allows overriding content type with :content_type" do
+    mock_app { get('/') { json({}, :content_type => "foo/bar") } }
+    get('/')["Content-Type"].should == "foo/bar"
+  end
+
+  it "accepts shorthands for :content_type" do
+    mock_app { get('/') { json({}, :content_type => :js) } }
+    get('/')["Content-Type"].should == "application/javascript;charset=utf-8"
+  end
+
+  describe "MultiJson integration" do
+    before do
+      ::MultiJson.should_receive(:encode)
+               .with(42, :adapter => :dummy_encoder)
+    end
+
+    it "uses the encoder specified in the options" do
+      mock_app do
+        get('/') { json 42, :encoder => :dummy_encoder }
+      end
+      get('/')
+    end
+
+    it "uses the encoder specified in settings.multi_json_encoder" do
+      mock_app do
+        set :multi_json_encoder, :dummy_encoder
+        get('/') { json 42 }
+      end
+      get('/')
+    end
+  end
+
+  describe('MultiJson Yajl')    { it_should_behave_like "a multi_json encoder", "yajl", :yajl           } unless defined? JRUBY_VERSION
+  describe('MultiJson JSON')    { it_should_behave_like "a multi_json encoder", "json", :json_gem       }
+  describe('MultiJson OkJson')  { it_should_behave_like "a multi_json encoder", nil,    :ok_json        }
+end


### PR DESCRIPTION
MultiJSON can clean up all the funky old JSON library detection stuff in Sinatra::JSON, but maintaining backward compatibility with all the old json_encoder options made it very messy, so I split it off into a separate module. 

I'd love to see Sinatra::MultiJSON replace Sinatra::JSON entirely (perhaps taking its name). Or, I can make one module that falls back when MultiJson doesn't understand the specified engine (e.g. :to_json). Let me know if you'd prefer it to look different.
