### PR TITLE
Modify cookie[]= method to support additional options

### DIFF
--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -87,8 +87,10 @@ module Sinatra
         response_cookies[key.to_s] || request_cookies[key.to_s]
       end
 
-      def []=(key, value)
-        @response.set_cookie key.to_s, @options.merge(:value => value)
+      def []=(key, options = {}, value)
+        options = @options.merge(options).merge(:value => value)
+
+        @response.set_cookie key.to_s, options
       end
 
       def assoc(key)

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -124,6 +124,13 @@ describe Sinatra::Cookies do
       cookie_jar['foo'].should be == 'bar'
     end
 
+    it 'sets a cookie with extra options' do
+      cookie_route do
+        cookies['foo', :path => '/baz'] = 'bar'
+        response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=' }
+      end.should include('path=/baz')
+    end
+
     it 'adds a value to the cookies hash' do
       cookie_route do
         cookies['foo'] = 'bar'


### PR DESCRIPTION
From what I understand, when using Sinatra::Cookie, if a cookie needed to have extra options (such as `:expire`, for example), then the global cookie options needed to change. I've modified the `[]=` method in the `Jar` class to support such extra options. For example, the following syntax would set an expiration on the '`:foo`' cookie:

```
cookie[:foo, :expires => 30*24*60*60] = 'bar'
# The 'foo' cookie will now expire in 30 days
```

The usefulness of this seems obvious, and I'm surprised that this hasn't been done before. I've also written an accompanying spec for this behavior, while all previous specs passed without modification.
