### PR TITLE
sinatra/cookies: cookies.delete did not pass the options to @response.delete_cookie

### DIFF
--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -111,7 +111,7 @@ module Sinatra
 
       def delete(key)
         result = self[key]
-        @response.delete_cookie(key.to_s)
+        @response.delete_cookie(key.to_s, @options)
         result
       end
 

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -154,11 +154,11 @@ describe Sinatra::Cookies do
       end.should be_nil
     end
 
-    it 'expiers existing cookies' do
+    it 'expires existing cookies' do
       cookie_route("foo=bar") do
         cookies.clear
         response['Set-Cookie']
-      end.should include("foo=; expires=Thu, 01-Jan-1970 00:00:00 GMT")
+      end.should include("foo=;", "expires=Thu, 01-Jan-1970 00:00:00 GMT")
     end
   end
 
@@ -185,16 +185,32 @@ describe Sinatra::Cookies do
     it 'removes response cookies from cookies hash' do
       cookie_route do
         cookies['foo'] = 'bar'
-        cookies.clear
+        cookies.delete 'foo'
         cookies['foo']
       end.should be_nil
     end
 
-    it 'expiers existing cookies' do
+    it 'expires existing cookies' do
       cookie_route("foo=bar") do
         cookies.delete 'foo'
         response['Set-Cookie']
-      end.should include("foo=; expires=Thu, 01-Jan-1970 00:00:00 GMT")
+      end.should include("foo=;", "expires=Thu, 01-Jan-1970 00:00:00 GMT")
+    end
+
+    it 'honours the app cookie_options' do
+      @cookie_app.class_eval do
+        set :cookie_options, {
+          :path => '/foo',
+          :domain => 'bar.com',
+          :secure => true,
+          :httponly => true
+        }
+      end
+      cookie_header = cookie_route("foo=bar") do
+        cookies.delete 'foo'
+        response['Set-Cookie']
+      end
+      cookie_header.should include("path=/foo;", "domain=bar.com;", "secure;", "HttpOnly")
     end
 
     it 'does not touch other cookies' do


### PR DESCRIPTION
Hi,

I noticed an issue when trying to delete cookies with custom cookie options. The custom path and domain were not being set on the response Set-Cookie header and therefore the cookie was not being deleted by the browser.

Hope this helps,

Thibaut
