### PR TITLE
Document sharing default settings (ConfigFile).

### DIFF
--- a/lib/sinatra/config_file.rb
+++ b/lib/sinatra/config_file.rb
@@ -95,9 +95,22 @@ module Sinatra
   #
   # Be aware that if you have a different environment, besides development,
   # test and production, you will also need to adjust the +environments+
-  # setting.  For instance, when you also have a staging environment:
+  # setting, otherwise the settings will not load.  For instance, when
+  # you also have a staging environment:
   #
   #     set :environments, %w{development test production staging}
+  #
+  # If you wish to provide defaults that may be shared among all the environments,
+  # this can be done by using one of the existing environments as the default using
+  # the YAML alias, and then overwriting values in the other environments:
+  #
+  #     development: &common_settings
+  #       foo: 'foo'
+  #       bar: 'bar'
+  #
+  #     production:
+  #       <<: *common_settings
+  #       bar: 'baz' # override the default value
   #
   module ConfigFile
 


### PR DESCRIPTION
This addresses #32 and #38.

Issue #32 suggest a change in the `ConfigFile#config_for_env(hash)`
method in order to allow a separate entry to use for shared settings,
while issue #38 provides an implementation of an additional,
non-environment, key `default` which default values can be added to.

It seems like the existing method of sharing settings does not have any
significant disadvantages, and just needed to be explicitly documented.
