### PR TITLE
Refactor multi-route specs

### DIFF
--- a/spec/multi_route_spec.rb
+++ b/spec/multi_route_spec.rb
@@ -2,25 +2,23 @@ require 'backports'
 require_relative 'spec_helper'
 
 describe Sinatra::MultiRoute do
-  before do
-    count = 0
+
+  it 'does not break normal routing' do
     mock_app do
-      set(:some_condition) { |_| count += 1 }
       register Sinatra::MultiRoute
       get('/') { 'normal' }
-      get('/foo', '/bar', :some_condition => true) { 'paths' }
-      route('PUT', 'POST', '/') { 'verb' }
-      route(:get, '/baz') { 'symbol as verb' }
     end
-    @count = count
-  end
 
-  it 'does still allow normal routing' do
     get('/').should be_ok
     body.should be == 'normal'
   end
 
   it 'supports multiple routes' do
+    mock_app do
+      register Sinatra::MultiRoute
+      get('/foo', '/bar') { 'paths' }
+    end
+
     get('/foo').should be_ok
     body.should be == 'paths'
     get('/bar').should be_ok
@@ -28,10 +26,22 @@ describe Sinatra::MultiRoute do
   end
 
   it 'triggers conditions' do
-    @count.should be == 4
+    count = 0
+    mock_app do
+      register Sinatra::MultiRoute
+      set(:some_condition) { |_| count += 1 }
+      get('/foo', '/bar', :some_condition => true) { 'paths' }
+    end
+
+    count.should be == 4
   end
 
   it 'supports multiple verbs' do
+    mock_app do
+      register Sinatra::MultiRoute
+      route('PUT', 'POST', '/') { 'verb' }
+    end
+
     post('/').should be_ok
     body.should be == 'verb'
     put('/').should be_ok
@@ -39,6 +49,11 @@ describe Sinatra::MultiRoute do
   end
 
   it 'takes symbols as verbs' do
+    mock_app do
+      register Sinatra::MultiRoute
+      route(:get, '/baz') { 'symbol as verb' }
+    end
+
     get('/baz').should be_ok
     body.should be == 'symbol as verb'
   end


### PR DESCRIPTION
This makes the relationship between the setup and the spec explicit,
clarifying which bit of setup is actually being tested.
