### PR TITLE
Modify cookie[]= to take a hash of extra options

### DIFF
--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -88,7 +88,8 @@ module Sinatra
       end
 
       def []=(key, value)
-        @response.set_cookie key.to_s, @options.merge(:value => value)
+        options = (value.is_a?(Array) && value[1].is_a?(Hash)) ? value[1] : {}
+        @response.set_cookie key.to_s, @options.merge(options).merge(:value => value)
       end
 
       def assoc(key)

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -124,6 +124,13 @@ describe Sinatra::Cookies do
       cookie_jar['foo'].should be == 'bar'
     end
 
+    it 'sets a cookie with extra options' do
+      cookie_route do
+        cookies['foo'] = 'bar', {:path => '/baz'}
+        response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=' }
+      end.should include('path=/baz')
+    end
+
     it 'adds a value to the cookies hash' do
       cookie_route do
         cookies['foo'] = 'bar'


### PR DESCRIPTION
Based on pull request #66, with the suggested syntax changes. Doesn't work using `cookie[:key] = 'value', :option => 'asdf'` for whatever reason, so you need to wrap the extra hash in `{}`'s.

Also, on implementation: when `[]=(key, value)` gets called with a hash, `value` becomes an array containing both the bare value, as well as the hash. Just one of quirky Ruby things I guess.