### PR TITLE
Fix tests for jruby

### DIFF
--- a/spec/respond_with_spec.rb
+++ b/spec/respond_with_spec.rb
@@ -229,10 +229,12 @@ describe Sinatra::RespondWith do
         body.should == "hi"
       end
 
-      it 'uses yajl for json' do
-        respond_with :baz
-        req(:json).should be_ok
-        body.should == "\"yajl!\""
+      unless defined? JRUBY_VERSION
+        it 'uses yajl for json' do
+          respond_with :baz
+          req(:json).should be_ok
+          body.should == "\"yajl!\""
+        end
       end
     end
 


### PR DESCRIPTION
[yajl-ruby](https://github.com/brianmario/yajl-ruby) [doesn't support jruby](https://github.com/brianmario/yajl-ruby/blob/master/.travis.yml). However, [this test](https://github.com/patriciomacadden/sinatra-contrib/blob/master/spec/respond_with_spec.rb#L232) was failing because it was being run on jruby.
