### PR TITLE
modified code snippet to reflect that accept returns an AcceptType object instead of a string since v1.4.0

### DIFF
--- a/lib/sinatra/respond_with.rb
+++ b/lib/sinatra/respond_with.rb
@@ -14,7 +14,7 @@ module Sinatra
   #   get '/' do
   #     data = { :name => 'example' }
   #     request.accept.each do |type|
-  #       case type
+  #       case type.to_s
   #       when 'text/html'
   #         halt haml(:index, :locals => data)
   #       when 'text/json'


### PR DESCRIPTION
Fixed a broken documentation snippet.
