### PR TITLE
unset domain for localhost by default and support options when setting cookie

### DIFF
--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -21,6 +21,21 @@ module Sinatra
   #     redirect to('/')
   #   end
   #
+  # Globally set default cookies options:
+  #
+  #  set :cookie_options,
+  #    :domain => "mydomain.com",
+  #    :path => "/mypath",
+  #    :secure => false,
+  #    :httponly => false
+  #
+  # Write cookie with options:
+  #
+  #   get '/set' do
+  #     cookies[:something] = {:value => 'foobar', :path => "/mypath", :domain => "mydomain.com"}
+  #     redirect to('/')
+  #   end
+  #
   # And generally behaves like a hash:
   #
   #   get '/demo' do
@@ -66,13 +81,11 @@ module Sinatra
         @deleted         = []
 
         @options = {
-          :path     => @request.script_name,
-          :domain   => @request.host,
+          :path     => @request.script_name.to_s.empty? ? '/' : @request.script_name,
+          :domain   => @request.host == 'localhost' ? nil : @request.host,
           :secure   => @request.secure?,
           :httponly => true
         }
-
-        @options[:path] = '/' if @options[:path].to_s.empty?
 
         if app.settings.respond_to? :cookie_options
           @options.merge! app.settings.cookie_options
@@ -88,7 +101,7 @@ module Sinatra
       end
 
       def []=(key, value)
-        @response.set_cookie key.to_s, @options.merge(:value => value)
+        @response.set_cookie key.to_s, @options.merge(value.is_a?(Hash) ? value : {:value => value})
       end
 
       def assoc(key)

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -9,7 +9,7 @@ describe Sinatra::Cookies do
       result = instance_eval(&block)
       "ok"
     end
-    get '/'
+    get '/', {}, @headers || {}
     last_response.should be_ok
     body.should be == "ok"
     result
@@ -97,6 +97,14 @@ describe Sinatra::Cookies do
       end.should include('HttpOnly')
     end
 
+    it 'sets domain to nil if localhost' do
+      @headers = {'HTTP_HOST' => 'localhost'}
+      cookie_route do
+        cookies['foo'] = 'bar'
+        response['Set-Cookie']
+      end.should_not include("domain")
+    end
+
     it 'sets the domain' do
       cookie_route do
         cookies['foo'] = 'bar'
@@ -129,6 +137,28 @@ describe Sinatra::Cookies do
         cookies['foo'] = 'bar'
         cookies['foo']
       end.should be == 'bar'
+    end
+
+    it 'sets a cookie using hash value' do
+      cookie_route do
+        cookies['foo'] = {:value => 'bar'}
+        response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=bar' }
+      end
+    end
+
+    ["baz.com", "localhost"].each do |domain|
+      it 'sets a cookie options using hash' do
+        cookie_route do
+          cookies['foo'] = {
+            :value => 'bar',
+            :path => '/baz',
+            :domain => domain,
+            :secure => true,
+            :httponly => true
+          }
+          response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=bar' }
+        end.should include("path=/baz;", "domain=#{domain};", "secure;", "HttpOnly")
+      end
     end
   end
 

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -142,8 +142,8 @@ describe Sinatra::Cookies do
     it 'sets a cookie using hash value' do
       cookie_route do
         cookies['foo'] = {:value => 'bar'}
-        response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=bar' }
-      end
+        response['Set-Cookie'].lines.detect { |l| l.start_with? 'foo=' }
+      end.should include('foo=bar')
     end
 
     ["baz.com", "localhost"].each do |domain|


### PR DESCRIPTION
should fix #113 & #115

First, by default unset domain when `@request.host == 'localhost'`. Setting domain to localhost does not work in particular on Chrome. 

I also added the possibility to pass cookie options when setting a cookie. 

Added corresponding tests and doc. 