### PR TITLE
Fix for Issue 119.

### DIFF
--- a/lib/sinatra/namespace.rb
+++ b/lib/sinatra/namespace.rb
@@ -175,7 +175,7 @@ module Sinatra
       end
 
       def not_found(&block)
-        error(404, &block)
+        error(Sinatra::NotFound, &block)
       end
 
       def errors
@@ -187,9 +187,10 @@ module Sinatra
       end
 
       def error(*codes, &block)
-        args  = Sinatra::Base.send(:compile!, "ERROR", /^#{@pattern}/, block)
+        args  = Sinatra::Base.send(:compile!, "ERROR", regexpify(@pattern), block)
         codes = codes.map { |c| Array(c) }.flatten
         codes << Exception if codes.empty?
+
         codes.each do |c|
           errors = @errors[c] ||= []
           errors << args
@@ -255,7 +256,7 @@ module Sinatra
 
       def regexpify(pattern)
         pattern = Sinatra::Base.send(:compile, pattern).first.inspect
-        pattern.gsub! /^\/(\^|\\A)?|(\$|\\Z)?\/$/, ''
+        pattern.gsub! /^\/(\^|\\A)?|(\$|\\z)?\/$/, ''
         Regexp.new pattern
       end
 

--- a/spec/namespace_spec.rb
+++ b/spec/namespace_spec.rb
@@ -547,6 +547,24 @@ describe Sinatra::Namespace do
           get('/de/foo').status.should     eq 406
           last_response.body.should        eq 'methode nicht erlaubt' unless verb == :head
         end
+
+        it "allows custom error handlers when namespace is declared as /en/:id. Issue #119" do
+          mock_app {
+            class CError < StandardError;
+            end
+
+            error { raise "should not come here" }
+
+            namespace('/en/:id') do
+              error(CError) { 201 }
+              get '/?' do
+                raise CError
+              end
+            end
+          }
+
+          get('/en/1').status.should == 201
+        end
       end
 
       unless verb == :head


### PR DESCRIPTION
Make sure error blocks with custom Exceptions are handled when namespace is declared as '/foo/:id'. fixes #119.
