### PR TITLE
Adding default content for yield_content method

### DIFF
--- a/lib/sinatra/content_for.rb
+++ b/lib/sinatra/content_for.rb
@@ -27,6 +27,15 @@ module Sinatra
   #     # layout.erb
   #     <%= yield_content :some_key %>
   #
+  # If you have provided +yield_content+ with a block and no content for the
+  # specified key is found, it will render the results of the block provided
+  # to yield_content.
+  #
+  #     # layout.erb
+  #     <%= yield_content :some_key_with_no_content do %>
+  #       <chunk of="default html">...</chunk>
+  #     <% end %>
+  #
   # === Classic Application
   #
   # To use the helpers in a classic application all you need to do is require

--- a/lib/sinatra/content_for.rb
+++ b/lib/sinatra/content_for.rb
@@ -111,6 +111,7 @@ module Sinatra
     # Would pass <tt>1</tt> and <tt>2</tt> to all the blocks registered
     # for <tt>:head</tt>.
     def yield_content(key, *args)
+      return yield(*args) if block_given? && content_blocks[key.to_sym].empty?
       content_blocks[key.to_sym].map { |b| capture(*args, &b) }.join
     end
 

--- a/spec/content_for_spec.rb
+++ b/spec/content_for_spec.rb
@@ -33,6 +33,11 @@ describe Sinatra::ContentFor do
       yield_content(:foo).should be_empty
     end
 
+    it 'renders default content if no block matches the key and a default block is specified' do
+      content_for(:bar) { "bar" }
+      yield_content(:foo) { "foo" }.should == "foo"
+    end
+
     it 'renders multiple blocks with the same key' do
       content_for(:foo) { "foo" }
       content_for(:foo) { "bar" }
@@ -83,6 +88,11 @@ describe Sinatra::ContentFor do
         it 'does not render a block with a different key' do
           render inner, :different_key
           yield_content(:foo).should be_empty
+        end
+
+        it 'renders default content if no block matches the key and a default block is specified' do
+          render inner, :different_key
+          yield_content(:foo) { "foo" }.should == "foo"
         end
 
         it 'renders multiple blocks with the same key' do


### PR DESCRIPTION
Adding ability for the yield_content method in the content_for package to define default content in the absence of content for a given key