### PR TITLE
Add Sinatra::Runner For Managing Sinatra Servers

### DIFF
--- a/lib/sinatra/runner.rb
+++ b/lib/sinatra/runner.rb
@@ -43,73 +43,73 @@ require 'timeout'
 #
 # For an example, check https://github.com/apotonick/roar/blob/master/test/test_helper.rb
 module Sinatra
-	class Runner
-	  def app_file
-	    File.expand_path("../server.rb", __FILE__)
-	  end
+  class Runner
+    def app_file
+      File.expand_path("../server.rb", __FILE__)
+    end
 
-	  def run
-	    #puts command
-	    @pipe     = start
-	    @started  = Time.now
-	    warn "#{server} up and running on port #{port}" if ping
-	  end
+    def run
+      #puts command
+      @pipe     = start
+      @started  = Time.now
+      warn "#{server} up and running on port #{port}" if ping
+    end
 
-	  def kill
-	    return unless pipe
-	    Process.kill("KILL", pipe.pid)
-	  rescue NotImplementedError
-	    system "kill -9 #{pipe.pid}"
-	  rescue Errno::ESRCH
-	  end
+    def kill
+      return unless pipe
+      Process.kill("KILL", pipe.pid)
+    rescue NotImplementedError
+      system "kill -9 #{pipe.pid}"
+    rescue Errno::ESRCH
+    end
 
-	  def get(url)
-	    Timeout.timeout(1) { open("http://127.0.0.1:#{port}#{url}").read }
-	  end
+    def get(url)
+      Timeout.timeout(1) { open("http://127.0.0.1:#{port}#{url}").read }
+    end
 
-	  def log
-	    @log ||= ""
-	    loop { @log <<  pipe.read_nonblock(1) }
-	  rescue Exception
-	    @log
-	  end
+    def log
+      @log ||= ""
+      loop { @log <<  pipe.read_nonblock(1) }
+    rescue Exception
+      @log
+    end
 
-	private
-	  attr_accessor :pipe
+  private
+    attr_accessor :pipe
 
-	  def start
-	    IO.popen(command)
-	  end
+    def start
+      IO.popen(command)
+    end
 
-	  def command # to be overwritten
-	    "bundle exec ruby #{app_file} -p #{port} -e production"
-	  end
+    def command # to be overwritten
+      "bundle exec ruby #{app_file} -p #{port} -e production"
+    end
 
-	  def ping(timeout=30)
-	    loop do
-	      return if alive?
-	      if Time.now - @started > timeout
-	        $stderr.puts command, log
-	        fail "timeout"
-	      else
-	        sleep 0.1
-	      end
-	    end
-	  end
+    def ping(timeout=30)
+      loop do
+        return if alive?
+        if Time.now - @started > timeout
+          $stderr.puts command, log
+          fail "timeout"
+        else
+          sleep 0.1
+        end
+      end
+    end
 
-	  def alive?
-	    3.times { get(ping_path) }
-	    true
-	  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError, SystemCallError, OpenURI::HTTPError, Timeout::Error
-	    false
-	  end
+    def alive?
+      3.times { get(ping_path) }
+      true
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError, SystemCallError, OpenURI::HTTPError, Timeout::Error
+      false
+    end
 
-	  def ping_path # to be overwritten
-	    '/ping'
-	  end
+    def ping_path # to be overwritten
+      '/ping'
+    end
 
-	  def port # to be overwritten
-	    4567
-	  end
-	end
+    def port # to be overwritten
+      4567
+    end
+  end
 end

--- a/lib/sinatra/runner.rb
+++ b/lib/sinatra/runner.rb
@@ -1,4 +1,6 @@
 require 'open-uri'
+require 'net/http'
+require 'timeout'
 
 # Helps you spinning up and shutting down your own sinatra app. This is especially helpful for running
 # real network tests against a sinatra backend.
@@ -61,6 +63,17 @@ module Sinatra
 	  rescue Errno::ESRCH
 	  end
 
+	  def get(url)
+	    Timeout.timeout(1) { open("http://127.0.0.1:#{port}#{url}").read }
+	  end
+
+	  def log
+	    @log ||= ""
+	    loop { @log <<  pipe.read_nonblock(1) }
+	  rescue Exception
+	    @log
+	  end
+
 	private
 	  attr_accessor :pipe
 
@@ -89,17 +102,6 @@ module Sinatra
 	    true
 	  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError, SystemCallError, OpenURI::HTTPError, Timeout::Error
 	    false
-	  end
-
-	  def get(url)
-	    Timeout.timeout(1) { open("http://127.0.0.1:#{port}#{url}").read }
-	  end
-
-	  def log
-	    @log ||= ""
-	    loop { @log <<  pipe.read_nonblock(1) }
-	  rescue Exception
-	    @log
 	  end
 
 	  def ping_path # to be overwritten

--- a/lib/sinatra/runner.rb
+++ b/lib/sinatra/runner.rb
@@ -1,0 +1,113 @@
+require 'open-uri'
+
+# Helps you spinning up and shutting down your own sinatra app. This is especially helpful for running
+# real network tests against a sinatra backend.
+#
+# The backend server could look like the following (in test/server.rb).
+#
+# 	require "sinatra"
+#
+#		get "/" do
+#  		"Cheers from test server"
+# 	end
+#
+#		get "/ping" do
+#  		1
+# 	end
+#
+# Note that you need to implement a ping action for internal use.
+#
+# Next, you need to write your runner.
+#
+# 	require 'sinatra/runner'
+#
+#   class Runner < Sinatra::Runner
+#     def app_file
+#       File.expand_path("../server.rb", __FILE__)
+#     end
+# 	end
+#
+# Override Runner#app_file, #command, #port and #ping_path for customization.
+#
+# Whereever you need this test backend, here's how you manage it. The following example assumes you
+# have a test in your app that needs to be run against your test backend.
+#
+# 	runner = ServerRunner.new
+#   runner.run
+#
+#  	# ..tests against localhost:4567 here..
+#
+# 	runner.kill
+#
+# For an example, check https://github.com/apotonick/roar/blob/master/test/test_helper.rb
+module Sinatra
+	class Runner
+	  def app_file
+	    File.expand_path("../server.rb", __FILE__)
+	  end
+
+	  def run
+	    #puts command
+	    @pipe     = start
+	    @started  = Time.now
+	    warn "#{server} up and running on port #{port}" if ping
+	  end
+
+	  def kill
+	    return unless pipe
+	    Process.kill("KILL", pipe.pid)
+	  rescue NotImplementedError
+	    system "kill -9 #{pipe.pid}"
+	  rescue Errno::ESRCH
+	  end
+
+	private
+	  attr_accessor :pipe
+
+	  def start
+	    IO.popen(command)
+	  end
+
+	  def command # to be overwritten
+	    "bundle exec ruby #{app_file} -p #{port} -e production"
+	  end
+
+	  def ping(timeout=30)
+	    loop do
+	      return if alive?
+	      if Time.now - @started > timeout
+	        $stderr.puts command, log
+	        fail "timeout"
+	      else
+	        sleep 0.1
+	      end
+	    end
+	  end
+
+	  def alive?
+	    3.times { get(ping_path) }
+	    true
+	  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError, SystemCallError, OpenURI::HTTPError, Timeout::Error
+	    false
+	  end
+
+	  def get(url)
+	    Timeout.timeout(1) { open("http://127.0.0.1:#{port}#{url}").read }
+	  end
+
+	  def log
+	    @log ||= ""
+	    loop { @log <<  pipe.read_nonblock(1) }
+	  rescue Exception
+	    @log
+	  end
+
+	  def ping_path # to be overwritten
+	    '/ping'
+	  end
+
+	  def port # to be overwritten
+	    4567
+	  end
+	end
+end

--- a/lib/sinatra/runner.rb
+++ b/lib/sinatra/runner.rb
@@ -5,39 +5,39 @@ require 'open-uri'
 #
 # The backend server could look like the following (in test/server.rb).
 #
-# 	require "sinatra"
+#   require "sinatra"
 #
-#		get "/" do
-#  		"Cheers from test server"
-# 	end
+#   get "/" do
+#     "Cheers from test server"
+#   end
 #
-#		get "/ping" do
-#  		1
-# 	end
+#   get "/ping" do
+#     1
+#   end
 #
 # Note that you need to implement a ping action for internal use.
 #
 # Next, you need to write your runner.
 #
-# 	require 'sinatra/runner'
+#   require 'sinatra/runner'
 #
 #   class Runner < Sinatra::Runner
 #     def app_file
 #       File.expand_path("../server.rb", __FILE__)
 #     end
-# 	end
+#   end
 #
 # Override Runner#app_file, #command, #port and #ping_path for customization.
 #
 # Whereever you need this test backend, here's how you manage it. The following example assumes you
 # have a test in your app that needs to be run against your test backend.
 #
-# 	runner = ServerRunner.new
+#   runner = ServerRunner.new
 #   runner.run
 #
-#  	# ..tests against localhost:4567 here..
+#   # ..tests against localhost:4567 here..
 #
-# 	runner.kill
+#   runner.kill
 #
 # For an example, check https://github.com/apotonick/roar/blob/master/test/test_helper.rb
 module Sinatra

--- a/lib/sinatra/runner.rb
+++ b/lib/sinatra/runner.rb
@@ -29,7 +29,7 @@ require 'timeout'
 #     end
 #   end
 #
-# Override Runner#app_file, #command, #port and #ping_path for customization.
+# Override Runner#app_file, #command, #port, #protocol and #ping_path for customization.
 #
 # Whereever you need this test backend, here's how you manage it. The following example assumes you
 # have a test in your app that needs to be run against your test backend.

--- a/lib/sinatra/runner.rb
+++ b/lib/sinatra/runner.rb
@@ -64,7 +64,7 @@ module Sinatra
     end
 
     def get(url)
-      Timeout.timeout(1) { URI.parse("#{protocol}://127.0.0.1:#{port}#{url}").read }
+      Timeout.timeout(1) { get_url("#{protocol}://127.0.0.1:#{port}#{url}") }
     end
 
     def log
@@ -114,6 +114,21 @@ module Sinatra
 
     def protocol
       "http"
+    end
+
+    def get_url(url)
+      uri = URI.parse(url)
+
+      return uri.read unless protocol == "https"
+      get_https_url(uri)
+    end
+
+    def get_https_url(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl      = true
+      http.verify_mode  = OpenSSL::SSL::VERIFY_NONE
+      request = Net::HTTP::Get.new(uri.request_uri)
+      http.request(request).body
     end
   end
 end

--- a/lib/sinatra/runner.rb
+++ b/lib/sinatra/runner.rb
@@ -14,7 +14,7 @@ require 'timeout'
 #   end
 #
 #   get "/ping" do
-#     1
+#     "1"
 #   end
 #
 # Note that you need to implement a ping action for internal use.
@@ -64,7 +64,7 @@ module Sinatra
     end
 
     def get(url)
-      Timeout.timeout(1) { open("http://127.0.0.1:#{port}#{url}").read }
+      Timeout.timeout(1) { open("#{protocol}://127.0.0.1:#{port}#{url}").read }
     end
 
     def log
@@ -110,6 +110,10 @@ module Sinatra
 
     def port # to be overwritten
       4567
+    end
+
+    def protocol
+      "http"
     end
   end
 end

--- a/lib/sinatra/runner.rb
+++ b/lib/sinatra/runner.rb
@@ -64,7 +64,7 @@ module Sinatra
     end
 
     def get(url)
-      Timeout.timeout(1) { open("#{protocol}://127.0.0.1:#{port}#{url}").read }
+      Timeout.timeout(1) { URI.parse("#{protocol}://127.0.0.1:#{port}#{url}").read }
     end
 
     def log


### PR DESCRIPTION
This is extremely useful e.g. if you wanna test your REST client against a real backend (with real network calls). Assuming the test backend is a sinatra app, this class helps you to start and stop the server in your test.