### PR TITLE
Add support for custom loggers (controlled via `logger` setting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Currently included:
   depending on the incoming request. Adds helpers `respond_to` and
   `respond_with`.
 
+* `sinatra/custom_logger`: This extension allows you to define your own
+  logger instance using +logger+ setting. That logger then will
+  be available as #logger helper method in your routes and views.
 
 ## Custom Extensions
 

--- a/lib/sinatra/contrib.rb
+++ b/lib/sinatra/contrib.rb
@@ -15,6 +15,7 @@ module Sinatra
       helpers :Capture
       helpers :ContentFor
       helpers :Cookies
+      helpers :CustomLogger
       helpers :EngineTracking
       helpers :JSON
       helpers :LinkHeader

--- a/lib/sinatra/custom_logger.rb
+++ b/lib/sinatra/custom_logger.rb
@@ -1,0 +1,60 @@
+module Sinatra
+
+  # = Sinatra::CustomLogger
+  #
+  # CustomLogger extension allows you to define your own logger instance
+  # using +logger+ setting. That logger then will be available
+  # as #logger helper method in your routes and views.
+  #
+  # == Usage
+  #
+  # === Classic Application
+  #
+  # To define your custom logger instance in a classic application:
+  #
+  #     require 'sinatra'
+  #     require 'sinatra/custom_logger'
+  #     require 'logger'
+  #
+  #     set :logger, Logger.new(STDOUT)
+  #
+  #     get '/' do
+  #       logger.info 'Some message' # STDOUT logger is used
+  #       # Other code...
+  #     end
+  #
+  # === Modular Application
+  #
+  # The same for modular application:
+  #
+  #     require 'sinatra/base'
+  #     require 'sinatra/custom_logger'
+  #     require 'logger'
+  #
+  #     class MyApp < Sinatra::Base
+  #       helpers Sinatra::CustomLogger
+  #
+  #       configure :development, :production do
+  #         logger = Logger.new(File.open("#{root}/log/#{environment}.log", 'a'))
+  #         logger.level = Logger::DEBUG if development?
+  #         set :logger, logger
+  #       end
+  #
+  #       get '/' do
+  #         logger.info 'Some message' # File-based logger is used
+  #         # Other code...
+  #       end
+  #     end
+  #
+  module CustomLogger
+    def logger
+      if settings.respond_to?(:logger)
+        settings.logger
+      else
+        request.logger
+      end
+    end
+  end
+
+  helpers CustomLogger
+end

--- a/sinatra-contrib.gemspec
+++ b/sinatra-contrib.gemspec
@@ -47,7 +47,8 @@ Gem::Specification.new do |s|
     "Thibaut Sacreste",
     "Uchio KONDO",
     "Will Bailey",
-    "undr"
+    "undr",
+    "Alexey Chernenkov"
   ]
 
   # generated from git shortlog -sne
@@ -90,7 +91,8 @@ Gem::Specification.new do |s|
     "thibaut.sacreste@gmail.com",
     "udzura@udzura.jp",
     "will.bailey@gmail.com",
-    "undr@yandex.ru"
+    "undr@yandex.ru",
+    "laise@pisem.net"
   ]
 
   # generated from git ls-files
@@ -107,6 +109,7 @@ Gem::Specification.new do |s|
     "lib/sinatra/contrib/setup.rb",
     "lib/sinatra/contrib/version.rb",
     "lib/sinatra/cookies.rb",
+    "lib/sinatra/custom_logger.rb",
     "lib/sinatra/decompile.rb",
     "lib/sinatra/engine_tracking.rb",
     "lib/sinatra/extension.rb",
@@ -161,6 +164,7 @@ Gem::Specification.new do |s|
     "spec/content_for/takes_values.slim",
     "spec/content_for_spec.rb",
     "spec/cookies_spec.rb",
+    "spec/custom_logger_spec.rb",
     "spec/decompile_spec.rb",
     "spec/extension_spec.rb",
     "spec/json_spec.rb",

--- a/spec/custom_logger_spec.rb
+++ b/spec/custom_logger_spec.rb
@@ -1,0 +1,43 @@
+require 'backports'
+require_relative 'spec_helper'
+
+describe Sinatra::CustomLogger do
+  before do
+    rack_logger = @rack_logger = double
+    mock_app do
+      helpers Sinatra::CustomLogger
+
+      before do
+        env['rack.logger'] = rack_logger
+      end
+
+      get '/' do
+        logger.info 'Logged message'
+        'Response'
+      end
+    end
+  end
+
+  describe '#logger' do
+    it 'falls back to request.logger' do
+      expect(@rack_logger).to receive(:info).with('Logged message')
+      get '/'
+    end
+
+    context 'logger setting is set' do
+      before do
+        custom_logger = @custom_logger = double
+        @app.class_eval do
+          configure do
+            set :logger, custom_logger
+          end
+        end
+      end
+
+      it 'calls custom logger' do
+        expect(@custom_logger).to receive(:info).with('Logged message')
+        get '/'
+      end
+    end
+  end
+end


### PR DESCRIPTION
**CustomLogger** extension allows you to define your own logger instance using `logger` setting.
That logger then will be available as #logger helper method in your routes and views.
### Classic Application

To define your custom logger instance in a classic application:

``` ruby
require 'sinatra'
require 'sinatra/custom_logger'
require 'logger'

set :logger, Logger.new(STDOUT)

get '/' do
  logger.info 'Some message' # STDOUT logger is used
  # Other code...
end
```
### Modular Application

The same for modular application:

``` ruby
require 'sinatra/base'
require 'sinatra/custom_logger'
require 'logger'

class MyApp < Sinatra::Base
  helpers Sinatra::CustomLogger

  configure :development, :production do
    logger = Logger.new(File.open("#{root}/log/#{environment}.log", 'a'))
    logger.level = Logger::DEBUG if development?
    set :logger, logger
  end

  get '/' do
    logger.info 'Some message' # File-based logger is used
    # Other code...
  end
end
```
