### PR TITLE
Only require the parts of backports that are actually used

### DIFF
--- a/lib/sinatra/capture.rb
+++ b/lib/sinatra/capture.rb
@@ -1,6 +1,7 @@
 require 'sinatra/base'
 require 'sinatra/engine_tracking'
-require 'backports'
+require 'backports/rails/kernel'
+require 'backports/1.9.1/string/clear'
 
 module Sinatra
   #

--- a/lib/sinatra/contrib/setup.rb
+++ b/lib/sinatra/contrib/setup.rb
@@ -1,6 +1,6 @@
 require 'sinatra/base'
 require 'sinatra/contrib/version'
-require 'backports'
+require 'backports/rails/string'
 
 module Sinatra
   module Contrib

--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -1,5 +1,6 @@
 require 'sinatra/base'
-require 'backports'
+require 'backports/1.9.2/hash/select'
+require 'backports/1.9.1/hash/key'
 
 module Sinatra
   # = Sinatra::Cookies

--- a/lib/sinatra/decompile.rb
+++ b/lib/sinatra/decompile.rb
@@ -1,5 +1,5 @@
 require 'sinatra/base'
-require 'backports'
+require 'backports/rails/kernel'
 require 'uri'
 
 module Sinatra

--- a/lib/sinatra/namespace.rb
+++ b/lib/sinatra/namespace.rb
@@ -1,4 +1,4 @@
-require 'backports'
+require 'backports/1.9.2/kernel/singleton_class'
 require 'sinatra/base'
 require 'sinatra/decompile'
 

--- a/lib/sinatra/streaming.rb
+++ b/lib/sinatra/streaming.rb
@@ -1,5 +1,6 @@
 require 'sinatra/base'
-require 'backports'
+require 'backports/1.9.1/string/chr'
+require 'backports/1.8.7/enumerator/each'
 
 module Sinatra
 

--- a/spec/streaming_spec.rb
+++ b/spec/streaming_spec.rb
@@ -1,4 +1,5 @@
-require 'backports'
+require 'backports/1.9.1/kernel/public_send'
+require 'backports/1.9.1/enumerator/new'
 require 'spec_helper'
 
 describe Sinatra::Streaming do


### PR DESCRIPTION
Relates to #105. 

It partially addresses the original concern there (and others) by reducing the number of monkey patches implicitly required into the runtime of projects using sinatra-contrib.

In #105, @zzak said:

> I would welcome a patch to remove the dependency on backports as long as we don't actually break backwards compatibility.

This is a step in that direction. It removes all `require "backports"` and replaces them with requires to explicit modules in the backports gem that provide just the functionality that is relied upon (as judged by passing tests in 1.8.7). If one wished to remove the dependency entirely, the surface area for work to do is now smaller. There are also some low-hanging items that could safely be changed to no longer require backports (e.g. `{}.key(:value)` -> `{}.index(:value)`).