### PR TITLE
Add Sinatra::JSONRequest module with body_as_json helper

### DIFF
--- a/lib/sinatra/json_request.rb
+++ b/lib/sinatra/json_request.rb
@@ -1,0 +1,58 @@
+require 'sinatra/base'
+require 'multi_json'
+module Sinatra
+
+  # = Sinatra::JSONRequest
+  #
+  # <tt>Sinatra::JSONRequest</tt> adds a helper method, called +body_as_json+, for
+  # handling requests with json bodies.
+  #
+  # == Usage
+  #
+  # === Modular Application
+  #
+  # In a modular application you need to require and then include the helper
+  #
+  #     require "sinatra/base"
+  #     require "sinatra/json_request"
+  #
+  #     class MyApp < Sinatra::Base
+  #       helpers Sinatra::JSONRequest
+  #       # define a route that uses the helper
+  #       post '/' do
+  #         body = body_as_json
+  #
+  #         return body.to_json
+  #       end
+  #     end
+  #
+  module JSONRequest
+
+    # Return the raw, unprocessed request body
+    #
+    # @return [String]
+    def raw_body
+      # Rewind the StringIO object in case somebody else read it first
+      request.body.rewind
+      return request.body.read
+    end
+
+    # Process and parse the request body as JSON
+    #
+    # Will halt and return a 400 status code if there is something wrong with
+    # the body
+    #
+    def body_as_json
+      body = raw_body
+
+      halt 400 if body.nil? || body.empty?
+
+      begin
+        return ::MultiJson.load(body)
+      rescue MultiJson::ParseError
+        logger.error "MultiJson::ParserError encountered parsing the request body (#{body})"
+        halt 400
+      end
+    end
+  end
+end

--- a/spec/json_request_spec.rb
+++ b/spec/json_request_spec.rb
@@ -1,0 +1,62 @@
+require 'multi_json'
+
+require 'spec_helper'
+require 'rack/test'
+
+require 'sinatra/json'
+require 'sinatra/json_request'
+
+class MockApp < Sinatra::Application
+  helpers Sinatra::JSONRequest
+  helpers Sinatra::JSON
+
+  # post '/' with body '{"foo" : bar"}' should return 200, '["foo"]'
+  post '/' do
+    body = body_as_json
+
+    if body.is_a? Hash
+      json body.keys
+    else
+      halt 401
+    end
+  end
+end
+
+describe Sinatra::JSONRequest do
+  include Rack::Test::Methods
+
+  def app
+    MockApp
+  end
+
+  subject { post '/', body }
+
+  context 'A request with a valid json body' do
+    let(:body) { MultiJson.dump({ 'foo' => 'bar' }) }
+
+    its(:status) { should be 200 }
+
+    its(:body) { should eql MultiJson.dump(['foo']) }
+  end
+
+  context 'A request with a nil body' do
+    let(:body) { nil }
+
+    its(:status) { should be 400 }
+    its(:body) { should be_empty }
+  end
+
+  context 'A request with an empty body' do
+    let(:body) { '' }
+
+    its(:status) { should be 400 }
+    its(:body) { should be_empty }
+  end
+
+  context 'A request with a body that is not proper json' do
+    let(:body) { 'not json' }
+
+    its(:status) { should be 400 }
+    its(:body) { should be_empty }
+  end
+end


### PR DESCRIPTION
We've found this useful in dealing with json request bodies; it abstracts away the "is there a non-nil/non-empty body?  Is it valid JSON?" and returns the parsed body.