### PR TITLE
Add Sinatra::Subroute, allowing an app to make a request to another endpoint in the app.

### DIFF
--- a/lib/sinatra/subroute.rb
+++ b/lib/sinatra/subroute.rb
@@ -1,0 +1,76 @@
+require 'sinatra/base'
+
+module Sinatra
+  # = Sinatra::Subroute
+  #
+  # <tt>Sinatra::Subroute</tt> adds a helper method, +subroute!+, for
+  # hitting other endpoints within your application as part of a request.
+  # Note that the request is made directly as a call to the appriopriate method
+  # within your app - no added HTTP roundtrip.
+  #
+  # == Usage
+  #
+  # === Modular Application
+  #
+  # In a modular application you need to require and then include the helper
+  #
+  #     require "sinatra/base"
+  #     require "sinatra/subroute"
+  #
+  #     class MyApp < Sinatra::Base
+  #       helpers Sinatra::Subroute
+  #
+  #       get '/target/:id' do |id|
+  #         status 200
+  #         json param[:id]
+  #       end
+  #
+  #       post '/target/:id' do |id|
+  #         status 201
+  #         json param[:id]
+  #       end
+  #
+  #       # One use case is building a response from data supplied by multiple
+  #       # existing API endpoints
+  #       get '/source' do
+  #         get_status, get_body = subroute!('/target/1')
+  #         post_status, post_body = subroute!('/target/1', :request_method => 'POST')
+  #
+  #         result = {:get => [get_status, get_body], :post => [post_status, post_body]}
+  #
+  #         status get_status
+  #         json result
+  #       end
+  #
+  #       # Another use case is making friendly or default routes for RESTful
+  #       # APIs
+  #       get '/' do
+  #         return subroute!("/user/#{current_user.id}")
+  #       end
+  #     end
+  #
+  module Subroute
+    HTTP_METHODS = %w(DELETE GET HEAD OPTIONS LINK PATCH POST PUT TRACE UNLINK).freeze
+
+    def subroute!(relative_path, options={})
+      # Create a copy of our app instance to preserve the state of the
+      # caller's env hash
+      subserver = dup
+      request_opts = {'PATH_INFO' => relative_path}
+
+      request_opts['REQUEST_METHOD'] = options.delete(:request_method).upcase if options[:request_method]
+      http_verb = request_opts['REQUEST_METHOD'] || subserver.request.request_method
+
+      raise ArgumentError, "Invalid http method: #{http_verb}" unless HTTP_METHODS.include?(http_verb)
+
+      # modify rack environment using Rack::Request - store passed in key/value
+      # pairs into hash associated with the parameters of the current http verb
+      options.each { |k,v| subserver.request.update_param(k, v) }
+      # Invoking Sinatra::Base#call! on our duplicated app instance. Sinatra's
+      # call will dup the app instance and then call!, so skip Sinatra's dup
+      # since we've done that here.
+      subcode, subheaders, body = subserver.call!(env.merge(request_opts))
+      return [subcode, body.first]
+    end
+  end
+end

--- a/spec/subroute_spec.rb
+++ b/spec/subroute_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+require 'multi_json'
+require 'sinatra/json'
+
+require 'sinatra/subroute'
+
+class MockApp < Sinatra::Application
+  include Sinatra::Subroute
+  include Sinatra::JSON
+
+  # Target test routes
+  get '/test_route' do
+    status 200
+    json params
+  end
+
+  put '/test_route' do
+    status 200
+    json params
+  end
+
+  delete '/test_delete' do
+    status 201
+    json :deleted => true
+  end
+
+  # Subrouted test routes
+  get '/subrouted' do
+    subroute!('/test_route')
+  end
+
+  get '/subrouted/:id' do |id|
+    subroute!('/test_route', :id => id)
+  end
+
+  put '/subrouted/request_params' do
+    subroute!('/test_route', 'key' => 'value')
+  end
+
+  # Subrouted, with a changed HTTP verb
+  get '/test_delete' do
+    subroute!('/test_delete', :request_method => 'DELETE')
+  end
+
+  # Subrouted to multiple target routes
+  get '/multiroute' do
+    subroute!('/test_delete', :request_method => 'DELETE')
+    subroute!('/test_route', :id => 1)
+  end
+end
+
+describe Sinatra::Subroute do
+  describe '#subroute!' do
+    let(:route) { '/test_route' }
+    let(:original) { get route }
+
+    subject(:subrouted) { get "/subrouted" }
+
+    def app
+      MockApp
+    end
+
+    context "without params" do
+      it 'should return the status code and body of the route' do
+        expect([subrouted.status, subrouted.body]).to eql [original.status, original.body]
+      end
+    end
+
+    context "with params" do
+      let(:id) { 1 }
+      let(:body) { MultiJson.dump({ :key => 'value', :id => "#{id}" }) }
+
+
+      context 'a get route' do
+        subject(:subrouted) { get "/subrouted/#{id}?key=value" }
+
+        it 'should return expected value' do
+          expect([subrouted.status, subrouted.body]).to eql [200, body]
+        end
+      end
+
+      context 'params added by subrouter, non-GET method' do
+        subject(:subrouted) { put '/subrouted/request_params' }
+
+        it 'should return expected value' do
+          expect([subrouted.status, subrouted.body]).to eql [200, MultiJson.dump({ 'key' => 'value' })]
+        end
+      end
+    end
+
+    context 'changing the http verb' do
+      context 'to a valid verb' do
+        subject(:subrouted) { get "/test_delete" }
+
+        its(:status) { should be 201 }
+
+        it 'should return expected output' do
+          expect(JSON.parse(subrouted.body)['deleted']).to be_true
+        end
+      end
+
+      context 'to an invalid verb' do
+        subject(:subrouted) { subroute!('/test_delete_invalid', :request_path => 'DELATE') }
+
+        it 'should throw an error' do
+          expect { subrouted }.to raise_error
+        end
+      end
+
+      context 'with multiple subroutes' do
+        subject(:subrouted) { get '/multiroute' }
+        it 'should return the status and body of the second subroute' do
+          expect([subrouted.status, subrouted.body]).to eql [200, MultiJson.dump({ :id => 1 })]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows for, e.g.:

```ruby
class App < Sinatra::Application
  helpers Sinatra::Subroute
  get '/target' do
    ...
  end

  get '/subrouted' do
    subroute!('/target')
  end
end
```

subroute! can also add or modify request params and the HTTP verb used.

(Originally from https://github.com/lookout/lookout-rack-utils)