### PR TITLE
allow checking setting existance with respond_to?

### DIFF
--- a/lib/sinatra/namespace.rb
+++ b/lib/sinatra/namespace.rb
@@ -268,6 +268,10 @@ module Sinatra
       def method_missing(method, *args, &block)
         base.send(method, *args, &block)
       end
+
+      def respond_to?(method, include_private = false)
+        super || base.respond_to?(method, include_private)
+      end
     end
 
     module BaseMethods

--- a/spec/namespace_spec.rb
+++ b/spec/namespace_spec.rb
@@ -704,5 +704,20 @@ describe Sinatra::Namespace do
       get('/foo/bar').status.should == 200
       last_response.body.should == '42'
     end
+
+    it 'allows checking setting existance with respond_to?' do
+      mock_app do
+        set :foo, 42
+
+        namespace '/foo' do
+          get '/bar' do
+            settings.respond_to?(:foo).to_s
+          end
+        end
+      end
+
+      get('/foo/bar').status.should == 200
+      last_response.body.should == 'true'
+    end
   end
 end


### PR DESCRIPTION
We need to define `respond_to?` method (it's better to use `respond_to_missing?` but it's not supported in ruby 1.8) when defining `method_missing`.

closes #28