### PR TITLE
RSpec deprecated testers

### DIFF
--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -32,7 +32,7 @@ describe Sinatra::Cookies do
     it 'runs the block' do
       ran = false
       cookie_route { ran = true }
-      ran.should be_true
+      ran.should be_truthy
     end
 
     it 'returns the block result' do
@@ -434,7 +434,7 @@ describe Sinatra::Cookies do
       cookie_route do
         cookies['foo'] = 'bar'
         cookies.empty?
-      end.should be_false
+      end.should be_falsey
     end
 
     it 'becomes true if response cookies are removed' do
@@ -442,14 +442,14 @@ describe Sinatra::Cookies do
         cookies['foo'] = 'bar'
         cookies.delete :foo
         cookies.empty?
-      end.should be_true
+      end.should be_truthy
     end
 
     it 'becomes true if request cookies are removed' do
       cookie_route('foo=bar') do
         cookies.delete :foo
         cookies.empty?
-      end.should be_true
+      end.should be_truthy
     end
 
     it 'becomes true after clear' do
@@ -457,7 +457,7 @@ describe Sinatra::Cookies do
         cookies['foo'] = 'bar'
         cookies.clear
         cookies.empty?
-      end.should be_true
+      end.should be_truthy
     end
   end
 
@@ -594,19 +594,19 @@ describe Sinatra::Cookies do
 
   describe :key? do
     it 'checks request cookies' do
-      cookies('foo=bar').key?('foo').should be_true
+      cookies('foo=bar').key?('foo').should be_truthy
     end
 
     it 'checks response cookies' do
       jar = cookies
       jar['foo'] = 'bar'
-      jar.key?(:foo).should be_true
+      jar.key?(:foo).should be_truthy
     end
 
     it 'does not use deleted cookies' do
       jar = cookies('foo=bar')
       jar.delete :foo
-      jar.key?('foo').should be_false
+      jar.key?('foo').should be_falsey
     end
   end
 
@@ -621,19 +621,19 @@ describe Sinatra::Cookies do
 
   describe :member? do
     it 'checks request cookies' do
-      cookies('foo=bar').member?('foo').should be_true
+      cookies('foo=bar').member?('foo').should be_truthy
     end
 
     it 'checks response cookies' do
       jar = cookies
       jar['foo'] = 'bar'
-      jar.member?(:foo).should be_true
+      jar.member?(:foo).should be_truthy
     end
 
     it 'does not use deleted cookies' do
       jar = cookies('foo=bar')
       jar.delete :foo
-      jar.member?('foo').should be_false
+      jar.member?('foo').should be_falsey
     end
   end
 
@@ -775,19 +775,19 @@ describe Sinatra::Cookies do
 
   describe :value? do
     it 'checks request cookies' do
-      cookies('foo=bar').value?('bar').should be_true
+      cookies('foo=bar').value?('bar').should be_truthy
     end
 
     it 'checks response cookies' do
       jar = cookies
       jar[:foo] = 'bar'
-      jar.value?('bar').should be_true
+      jar.value?('bar').should be_truthy
     end
 
     it 'does not use deleted cookies' do
       jar = cookies('foo=bar')
       jar.delete :foo
-      jar.value?('bar').should_not be_true
+      jar.value?('bar').should_not be_truthy
     end
   end
 

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -23,7 +23,7 @@ describe Sinatra::Extension do
   before { mock_app { register ExampleExtension }}
 
   it('allows using set') { settings.foo.should == :bar }
-  it('implements configure') { settings.reload_stuff.should be_false }
+  it('implements configure') { settings.reload_stuff.should be_falsey }
 
   it 'allows defing routes' do
     get('/').should be_ok

--- a/spec/namespace_spec.rb
+++ b/spec/namespace_spec.rb
@@ -118,14 +118,14 @@ describe Sinatra::Namespace do
           ran = false
           namespace('/foo') { before { ran = true }}
           send(verb, '/foo')
-          ran.should be_true
+          ran.should be_truthy
         end
 
         specify 'are not triggered for a different namespace' do
           ran = false
           namespace('/foo') { before { ran = true }}
           send(verb, '/fox')
-          ran.should be_false
+          ran.should be_falsey
         end
       end
 
@@ -134,14 +134,14 @@ describe Sinatra::Namespace do
           ran = false
           namespace('/foo') { after { ran = true }}
           send(verb, '/foo')
-          ran.should be_true
+          ran.should be_truthy
         end
 
         specify 'are not triggered for a different namespace' do
           ran = false
           namespace('/foo') { after { ran = true }}
           send(verb, '/fox')
-          ran.should be_false
+          ran.should be_falsey
         end
       end
 
@@ -176,13 +176,13 @@ describe Sinatra::Namespace do
               send(verb, '/*') { 'ok' }
             end
             send(verb, '/foo', {}, 'HTTP_HOST' => 'example.org', 'HTTP_ACCEPT' => 'text/plain')
-            ran.should be_false
+            ran.should be_falsey
             send(verb, '/foo', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/html')
-            ran.should be_false
+            ran.should be_falsey
             send(verb, '/bar', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/plain')
-            ran.should be_false
+            ran.should be_falsey
             send(verb, '/foo', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/plain')
-            ran.should be_true
+            ran.should be_truthy
           end
 
           specify 'are accepted in the after-filter' do
@@ -192,13 +192,13 @@ describe Sinatra::Namespace do
               send(verb, '/*') { 'ok' }
             end
             send(verb, '/foo', {}, 'HTTP_HOST' => 'example.org', 'HTTP_ACCEPT' => 'text/plain')
-            ran.should be_false
+            ran.should be_falsey
             send(verb, '/foo', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/html')
-            ran.should be_false
+            ran.should be_falsey
             send(verb, '/bar', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/plain')
-            ran.should be_false
+            ran.should be_falsey
             send(verb, '/foo', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/plain')
-            ran.should be_true
+            ran.should be_truthy
           end
         end
 
@@ -231,9 +231,9 @@ describe Sinatra::Namespace do
               send(verb) { 'ok' }
             end
             send(verb, '/foo', {}, 'HTTP_HOST' => 'example.org')
-            ran.should be_false
+            ran.should be_falsey
             send(verb, '/foo', {}, 'HTTP_HOST' => 'example.com')
-            ran.should be_true
+            ran.should be_truthy
           end
 
           specify 'are accepted in the route definition' do
@@ -252,11 +252,11 @@ describe Sinatra::Namespace do
                 send(verb) { 'ok' }
               end
               send(verb, '/', {}, 'HTTP_HOST' => 'example.org', 'HTTP_ACCEPT' => 'text/plain')
-              ran.should be_false
+              ran.should be_falsey
               send(verb, '/', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/html')
-              ran.should be_false
+              ran.should be_falsey
               send(verb, '/', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/plain')
-              ran.should be_true
+              ran.should be_truthy
             end
 
             specify 'are accepted in the filters' do
@@ -266,13 +266,13 @@ describe Sinatra::Namespace do
                 send(verb, '/*') { 'ok' }
               end
               send(verb, '/foo', {}, 'HTTP_HOST' => 'example.org', 'HTTP_ACCEPT' => 'text/plain')
-              ran.should be_false
+              ran.should be_falsey
               send(verb, '/foo', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/html')
-              ran.should be_false
+              ran.should be_falsey
               send(verb, '/far', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/plain')
-              ran.should be_false
+              ran.should be_falsey
               send(verb, '/foo', {}, 'HTTP_HOST' => 'example.com', 'HTTP_ACCEPT' => 'text/plain')
-              ran.should be_true
+              ran.should be_truthy
             end
           end
         end

--- a/spec/streaming_spec.rb
+++ b/spec/streaming_spec.rb
@@ -26,7 +26,7 @@ describe Sinatra::Streaming do
     it 'runs the given block' do
       ran = false
       stream { ran = true }
-      ran.should be_true
+      ran.should be_truthy
     end
 
     it 'returns the stream object' do
@@ -334,7 +334,7 @@ describe Sinatra::Streaming do
         fired = false
         out.callback { fired = true }
         out.close
-        fired.should be_true
+        fired.should be_truthy
       end
     end
 


### PR DESCRIPTION
Replace deprecated be_true/be_false testers with be_truthy/be_falsey. These errors were frustrating me while running tests.