### PR TITLE
remove tilt from dependence

### DIFF
--- a/sinatra-contrib.gemspec
+++ b/sinatra-contrib.gemspec
@@ -188,7 +188,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "sinatra",   "~> 1.4.0"
   s.add_dependency "backports", ">= 2.0"
-  s.add_dependency "tilt",      "~> 1.3"
   s.add_dependency "rack-test"
   s.add_dependency "rack-protection"
   s.add_dependency "multi_json"


### PR DESCRIPTION
the dependence of sinatra 1.4.6 is `tilt >= 1.3, < 3`.
the latest version of `tilt` is 2.0.1.
if you use sinatra, you have to use the latest version of `tilt`.
but the dependence of sinatra-contrib is `tilt ~> 1.3` and `sinatra ~> 1.4.0`.
if you use sinatra 1.4.6 and sinatra-contrib, you cannot use the latest version of `tilt`.
it becomes version mismatch.
the all dependence of sinatra 1.4.* is `tilt >= 1.3`.
if you remove `tilt` from the dependence of sinatra-contrib, no problem.