### PR TITLE
Allow users to yield a simple String to be rendered

### DIFF
--- a/lib/sinatra/content_for.rb
+++ b/lib/sinatra/content_for.rb
@@ -77,6 +77,10 @@ module Sinatra
     #       <script type="text/javascript" src="/foo.js"></script>
     #     <% end %>
     #
+    # You can also pass an immediate value instead of a block:
+    #
+    #     <% content_for :title, "foo" %>
+    #
     # You can call +content_for+ multiple times with the same key
     # (in the example +:head+), and when you render the blocks for
     # that key all of them will be rendered, in the same order you
@@ -84,7 +88,8 @@ module Sinatra
     #
     # Your blocks can also receive values, which are passed to them
     # by <tt>yield_content</tt>
-    def content_for(key, &block)
+    def content_for(key, value = nil, &block)
+      block ||= proc { |*| value }
       content_blocks[key.to_sym] << capture_later(&block)
     end
 

--- a/spec/content_for_spec.rb
+++ b/spec/content_for_spec.rb
@@ -65,6 +65,11 @@ describe Sinatra::ContentFor do
       clear_content_for(:foo)
       yield_content(:foo).should be_empty
     end
+
+    it 'takes an immediate value instead of a block' do
+      content_for(:foo, "foo")
+      yield_content(:foo).should == "foo"
+    end
   end
 
   # TODO: liquid radius markaby builder nokogiri


### PR DESCRIPTION
Added a missing feature from ActionView::Helpers::CaptureHelper
- http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-content_for
- https://github.com/rails/rails/blob/fcbd2e821e12fdf66ad2f28e97992a7cd75f529e/actionview/lib/action_view/helpers/capture_helper.rb#L149-L162
