### PR TITLE
lock libv8 to 3.16.14.7 for 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ gemspec
 gem 'sinatra', :github => 'sinatra/sinatra'
 
 group :development, :test do
+  
+  platform :ruby_18 do
+    gem 'libv8', '3.16.14.7'
+  end
+
   platform :ruby_18, :jruby do
     gem 'json'
     gem 'rdoc'


### PR DESCRIPTION
`libv8 3.16.14.8` has breaking changes for `ruby 1.8.7`. see https://travis-ci.org/sinatra/sinatra-contrib/jobs/69080234

locking to `libv8 3.16.14.7` for `ruby 1.8.x`