### PR TITLE
Allow cookies#[]= to take an options hash

### DIFF
--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -85,8 +85,9 @@ module Sinatra
         response_cookies[key.to_s] || request_cookies[key.to_s]
       end
 
-      def []=(key, value)
-        @response.set_cookie key.to_s, @options.merge(:value => value)
+      def []=(key, options)
+        options = { :value => options } if options.kind_of? String
+        @response.set_cookie key.to_s, @options.merge(options)
       end
 
       def assoc(key)

--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -85,9 +85,8 @@ module Sinatra
         response_cookies[key.to_s] || request_cookies[key.to_s]
       end
 
-      def []=(key, options)
-        options = { :value => options } if options.kind_of? String
-        @response.set_cookie key.to_s, @options.merge(options)
+      def []=(key, value, options = {})
+        @response.set_cookie key.to_s, @options.merge(options).merge(:value => value)
       end
 
       def assoc(key)

--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -85,7 +85,11 @@ module Sinatra
         response_cookies[key.to_s] || request_cookies[key.to_s]
       end
 
-      def []=(key, value, options = {})
+      def []=(key, value)
+        set key, value
+      end
+
+      def set(key, value, options = {})
         @response.set_cookie key.to_s, @options.merge(options).merge(:value => value)
       end
 


### PR DESCRIPTION
I have a need to be able to set different cookies with different options (e.g. a JWT cookie with `httpOnly` and `secure` and a XSRF prevention cookie without). This simple change preserves the existing functionality of `cookies#[]=` while allowing you to optionally pass in a hash of parameters as the value to be merged with `@options` and passed on to `Rack::Response#set_cookie`. I'm new here so I'm open to alternative solutions! 