### PR TITLE
Catch LoadError from Tilt with uninstalled template engine

### DIFF
--- a/lib/sinatra/respond_with.rb
+++ b/lib/sinatra/respond_with.rb
@@ -179,7 +179,11 @@ module Sinatra
           if Tilt.respond_to?(:mappings)
             klass = Tilt.mappings[Tilt.normalize(engine)].first
           else
-            klass = Tilt[engine]
+            begin
+              klass = Tilt[engine]
+            rescue LoadError
+              next
+            end
           end
           find_template(settings.views, template, klass) do |file|
             next unless File.exist? file


### PR DESCRIPTION
`template_for` looks through all the engines to find one that can handle the template. For versions of Tilt that don't respond to .mapping, this triggers a require on the engine its checking. So, for instance, if you are using the slim engine for html, you have to have the erubis and haml engines installed as well.