### PR TITLE
Add redirect_to method allowing redirects within a namespace

### DIFF
--- a/lib/sinatra/namespace.rb
+++ b/lib/sinatra/namespace.rb
@@ -89,6 +89,18 @@ module Sinatra
   #       # More admin routes...
   #     end
   #
+  # Redirecting within the namespace can be done using redirect_to:
+  #
+  #     namespace '/admin' do
+  #       get '/foo'  do
+  #         redirect_to '/bar' # Redirects to /admin/bar
+  #       end
+  #
+  #       get '/foo' do
+  #         redirect '/bar' # Redirects to /bar
+  #       end
+  #     end
+  #
   # === Classic Application Setup
   #
   # To be able to use namespaces in a classic application all you need to do is
@@ -136,6 +148,10 @@ module Sinatra
 
       def template_cache
         super.fetch(:nested, @namespace) { Tilt::Cache.new }
+      end
+
+      def redirect_to(uri, *args)
+        redirect("#{@namespace.pattern}#{uri}", *args)
       end
     end
 
@@ -225,6 +241,11 @@ module Sinatra
       def layout(name=:layout, &block)
         template name, &block
       end
+
+      def pattern
+        @pattern
+      end
+
 
       private
 

--- a/spec/namespace_spec.rb
+++ b/spec/namespace_spec.rb
@@ -25,6 +25,14 @@ describe Sinatra::Namespace do
         send(verb, '/foo/baz').should_not be_ok
       end
 
+      describe 'redirect_to' do
+        it 'redirect within namespace' do
+          namespace('/foo') { send(verb, '/bar') {  redirect_to '/foo_bar' }}
+          send(verb, '/foo/bar').should be_redirect
+          send(verb, '/foo/bar').location.should include("/foo/foo_bar")
+        end
+      end
+
       context 'when namespace is a string' do
         it 'accepts routes with no path' do
           namespace('/foo') { send(verb) { 'bar' } }


### PR DESCRIPTION
To avoid patching the ```redirect``` method I added ```redirect_to``` allowing requests to be redirected within the namespace:

```ruby
       namespace '/admin' do
         get '/foo'  do
           redirect_to '/bar' # Redirects to /admin/bar
         end
  
         get '/foo' do
           redirect '/bar' # Redirects to /bar
         end
       end
```

(edited some typo on the code snippet)