### PR TITLE
Update Bundler at before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     - rvm: jruby-head
     - rvm: rbx
     - env: sinatra=master
+before_install:
+  - gem update bundler
 notifications:
   recipients:
     - _@trevorbramble.com


### PR DESCRIPTION
Update Bundler to fix failing `bundle install` on Travis CI.

- https://github.com/bundler/bundler/issues/3558
- https://github.com/travis-ci/travis-ci/issues/3531