### PR TITLE
Avoid overwrite environments registering the module

### DIFF
--- a/lib/sinatra/config_file.rb
+++ b/lib/sinatra/config_file.rb
@@ -118,7 +118,7 @@ module Sinatra
     # When the extension is registered sets the +environments+ setting to the
     # traditional environments: development, test and production.
     def self.registered(base)
-      base.set :environments, %w[test production development]
+      base.set :environments, %w[test production development] unless base.respond_to? :environments
     end
 
     # Loads the configuration from the YAML files whose +paths+ are passed as


### PR DESCRIPTION
It takes me some minutes to figure out why my environments variable was overwritten. This small change will fix this problem for future people.