### PR TITLE
Change LinkHeaders to use ",\n" as delimiter in Link HTTP header

### DIFF
--- a/lib/sinatra/link_header.rb
+++ b/lib/sinatra/link_header.rb
@@ -90,7 +90,7 @@ module Sinatra
       link          = (response["Link"] ||= "")
 
       urls.map do |url|
-        link << "\n" unless link.empty?
+        link << ",\n" unless link.empty?
         link << (http_pattern % url)
         html_pattern % url
       end.join "\n"
@@ -117,7 +117,7 @@ module Sinatra
     def link_headers
       yield if block_given?
       return "" unless response.include? "Link"
-      response["Link"].lines.map do |line|
+      response["Link"].split(",\n").map do |line|
         url, *opts = line.split(';').map(&:strip)
         "<link href=\"#{url[1..-2]}\" #{opts.join " "} />"
       end.join "\n"

--- a/spec/link_header_spec.rb
+++ b/spec/link_header_spec.rb
@@ -41,7 +41,7 @@ describe Sinatra::LinkHeader do
     it "takes an options hash" do
       get '/'
       elements = ["<something>", "foo=\"bar\"", "rel=\"from-filter\""]
-      headers['Link'].lines.first.strip.split('; ').sort.should == elements
+      headers['Link'].split(",\n").first.strip.split('; ').sort.should == elements
     end
   end
 


### PR DESCRIPTION
Previously LinkHeaders would delimit multiple links with \n alone
like so:

    Link: <http://example.org/a>; rel="next"
          <http://example.org/b>; rel="prev"

However, comma + newline is used as the delimiter in the
specification's (https://tools.ietf.org/html/rfc5988#section-5.5)
examples and, additionally, it states:

> Note that extension relation types are REQUIRED to be absolute
> URIs in Link headers, and MUST be quoted if they contain a
> semicolon (";") or comma (",") (as these characters are used as
> delimiters in the header itself).

In comma + newline appears to be the standard in practice (e.g.
GitHub's API). This changes LinkHeaders to use comma + newline as
the delimieter between multiple links, e.g:

    Link: <http://example.org/a>; rel="next",
          <http://example.org/b>; rel="prev"