### PR TITLE
Allow erb syntax on yml config file

### DIFF
--- a/lib/sinatra/config_file.rb
+++ b/lib/sinatra/config_file.rb
@@ -128,9 +128,9 @@ module Sinatra
       Dir.chdir(root || '.') do
         paths.each do |pattern|
           Dir.glob(pattern) do |file|
+            raise UnsupportedConfigType unless ['.yml', '.erb'].include?(File.extname(file))
             $stderr.puts "loading config file '#{file}'" if logging?
-            document = IO.read(file)
-            document = ERB.new(document).result if file.split('.').include?('erb')
+            document = ERB.new(IO.read(file)).result
             yaml = config_for_env(YAML.load(document)) || {}
             yaml.each_pair do |key, value|
               for_env = config_for_env(value)
@@ -138,6 +138,12 @@ module Sinatra
             end
           end
         end
+      end
+    end
+
+    class UnsupportedConfigType < Exception
+      def message
+        'Invalid config file type, use .yml or .yml.erb'
       end
     end
 

--- a/spec/config_file/key_value.yml
+++ b/spec/config_file/key_value.yml
@@ -1,5 +1,6 @@
 ---
 foo: bar
+bar: <%= "bar" %>
 something: 42
 nested:
   a: 1

--- a/spec/config_file_spec.rb
+++ b/spec/config_file_spec.rb
@@ -22,7 +22,17 @@ describe Sinatra::ConfigFile do
     settings.nested[:a].should == 1
   end
 
-  it 'should render options in ERB tags' do
+  it 'should render options in ERB tags when using .yml files' do
+    config_file 'key_value.yml'
+    settings.bar.should == "bar"
+    settings.something.should == 42
+    settings.nested['a'].should == 1
+    settings.nested[:a].should == 1
+    settings.nested['b'].should == 2
+    settings.nested[:b].should == 2
+  end
+
+  it 'should render options in ERB tags when using .yml.erb files' do
     config_file 'key_value.yml.erb'
     settings.foo.should == "bar"
     settings.something.should == 42
@@ -30,6 +40,10 @@ describe Sinatra::ConfigFile do
     settings.nested[:a].should == 1
     settings.nested['b'].should == 2
     settings.nested[:b].should == 2
+  end
+
+  it 'should raise error if config file extension is not .yml or .erb' do
+    expect{ config_file 'config.txt' }.to raise_error(Sinatra::ConfigFile::UnsupportedConfigType)
   end
 
   it 'should recognize env specific settings per file' do


### PR DESCRIPTION
All `*.yml*` config files now accepts ERB syntax. Close #116 
