### PR TITLE
Remove ruby 1.8/1.9 version check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,7 @@ gemspec
 
 group :development, :test do
 
-  platform :ruby_18 do
-    gem 'libv8', '3.16.14.7'
-  end
-
-  platform :ruby_18, :jruby do
+  platform :jruby do
     gem 'json'
     gem 'rdoc'
   end
@@ -27,8 +23,7 @@ group :development, :test do
     gem 'redcarpet', '2.3.0'
     gem 'yajl-ruby'
     # ref is a dependency of therubyracer
-    # version 2 drops support for Rubies earlier than 1.9.3
-    gem 'ref', '< 2.0'
+    gem 'ref'
     gem 'therubyracer'
   end
 

--- a/lib/sinatra/cookies.rb
+++ b/lib/sinatra/cookies.rb
@@ -166,7 +166,7 @@ module Sinatra
       alias member?  has_key?
 
       def index(value)
-        warn "Hash#index is deprecated; use Hash#key" if RUBY_VERSION > '1.9'
+        warn "Hash#index is deprecated; use Hash#key"
         key(value)
       end
 

--- a/lib/sinatra/respond_with.rb
+++ b/lib/sinatra/respond_with.rb
@@ -1,8 +1,6 @@
 require 'sinatra/json'
 require 'sinatra/base'
 
-$KCODE = "UTF-8" unless RUBY_VERSION > "1.9.0"
-
 module Sinatra
   #
   # = Sinatra::RespondWith

--- a/sinatra-contrib.gemspec
+++ b/sinatra-contrib.gemspec
@@ -215,6 +215,8 @@ Gem::Specification.new do |s|
     "spec/params_spec.rb",
   ]
 
+  s.required_ruby_version = '>= 2.2.0'
+
   s.add_dependency "sinatra", "~> 1.4"
   s.add_dependency "backports", ">= 2.0"
   s.add_dependency "tilt",      ">= 1.3", "< 3"

--- a/sinatra-contrib.gemspec
+++ b/sinatra-contrib.gemspec
@@ -215,7 +215,7 @@ Gem::Specification.new do |s|
     "spec/params_spec.rb",
   ]
 
-  s.add_dependency "sinatra"
+  s.add_dependency "sinatra", "~> 1.4"
   s.add_dependency "backports", ">= 2.0"
   s.add_dependency "tilt",      ">= 1.3", "< 3"
   s.add_dependency "rack-test"

--- a/spec/capture_spec.rb
+++ b/spec/capture_spec.rb
@@ -44,7 +44,7 @@ describe Sinatra::Capture do
 
     it "handles ISO-8859-1 encoding" do
       render(:erb, "iso_8859_1").should == "ISO-8859-1 -"
-    end if RUBY_VERSION >= '1.9'
+    end
   end
 end
 

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -492,7 +492,7 @@ describe Sinatra::Cookies do
       error = if defined? JRUBY_VERSION
         IndexError
       else
-        RUBY_VERSION >= '1.9' ? KeyError : IndexError
+        KeyError
       end
       expect { cookies.fetch('foo') }.to raise_exception(error)
     end
@@ -559,22 +559,6 @@ describe Sinatra::Cookies do
       jar.should_not include('foo')
     end
   end
-
-  describe :index do
-    it 'checks request cookies' do
-      cookies('foo=bar').index('bar').should be == 'foo'
-    end
-
-    it 'checks response cookies' do
-      jar = cookies
-      jar['foo'] = 'bar'
-      jar.index('bar').should be == 'foo'
-    end
-
-    it 'returns nil when missing' do
-      cookies('foo=bar').index('baz').should be_nil
-    end
-  end if RUBY_VERSION < '1.9'
 
   describe :keep_if do
     it 'removes entries' do


### PR DESCRIPTION
Since we are now supporting only `>= 2.2.2` makes sense to remove `1.8/1.9` version check.