### PR TITLE
Fix issue prefixing routes with conditions

### DIFF
--- a/lib/sinatra/namespace.rb
+++ b/lib/sinatra/namespace.rb
@@ -268,6 +268,12 @@ module Sinatra
       def prefixed_path(a, b)
         return a || b || /.*/ unless a and b
 
+        concat_patterns(a, b)
+      end
+
+      def concat_patterns(a, b)
+        return Mustermann.new(b) if a == /.*/
+
         Mustermann.new(a) + Mustermann.new(b)
       end
 


### PR DESCRIPTION
Update to make the following namespace specs pass:

https://github.com/sinatra/sinatra-contrib/blob/9500d76/spec/namespace_spec.rb#L170-L209