### PR TITLE
Fix rspec old syntax warning

### DIFF
--- a/spec/capture_spec.rb
+++ b/spec/capture_spec.rb
@@ -43,7 +43,7 @@ describe Sinatra::Capture do
     end
 
     it "handles ISO-8859-1 encoding" do
-      render(:erb, "iso_8859_1").should == "ISO-8859-1 -"
+      expect(render(:erb, "iso_8859_1")).to eq("ISO-8859-1 -")
     end
   end
 end

--- a/spec/namespace_spec.rb
+++ b/spec/namespace_spec.rb
@@ -117,10 +117,10 @@ describe Sinatra::Namespace do
             namespace(/\/foo\/([^\/&?]+)\/bar\/([^\/&?]+)\//) { before { ran = true };}
 
             send(verb, '/bar/')
-            ran.should be false
+            expect(ran).to eq(false)
 
             send(verb, '/foo/1/bar/1/')
-            ran.should be true
+            expect(ran).to eq(true)
           end
 
           it 'trigger after filter' do
@@ -128,10 +128,10 @@ describe Sinatra::Namespace do
             namespace(/\/foo\/([^\/&?]+)\/bar\/([^\/&?]+)\//) { after { ran = true };}
 
             send(verb, '/bar/')
-            ran.should be false
+            expect(ran).to eq(false)
 
             send(verb, '/foo/1/bar/1/')
-            ran.should be true
+            expect(ran).to eq(true)
           end
         end
 
@@ -149,8 +149,8 @@ describe Sinatra::Namespace do
               end
             end
 
-            send(verb, '/foo/1/bar/1/').should be_ok
-            body.should == 'foo' unless verb == :head
+            expect(send(verb, '/foo/1/bar/1/')).to be_ok
+            expect(body).to eq('foo') unless verb == :head
           end
         end
       end
@@ -731,7 +731,7 @@ describe Sinatra::Namespace do
             end
             get('/bar') { }
           end
-          route[1].should eq Mustermann.new '/foo'
+          expect(route[1]).to eq(Mustermann.new '/foo')
         end
 
         specify 'prevent app-global settings from being changed' do


### PR DESCRIPTION
This patch clears all the warnings caused by using the old `rspec` syntax:

```
Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling thesyntax is deprecated.
Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead.
```